### PR TITLE
Make module compatible with MM 2.15.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mmm-mycalendar",
+  "version": "2.2.0",
+  "description": "This calendar module is functionally the same as the default calendar app, however its presentation is different.",
+  "main": "MMM-MyCalendar.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jclarke0000/MMM-MyCalendar.git"
+  },
+  "author": "Jeff Clarke",
+  "license": "UNLICENSED",
+  "bugs": {
+    "url": "https://github.com/jclarke0000/MMM-MyCalendar/issues"
+  },
+  "homepage": "https://github.com/jclarke0000/MMM-MyCalendar#readme",
+  "dependencies": {
+    "valid-url": "^1.0.9"
+  }
+}


### PR DESCRIPTION
MagicMirror removed the `valid-url` library in 2.15.0.

This PR adds a `package.json` that installs the module.