### PR TITLE
Load moment-timezone before timezone calculations

### DIFF
--- a/calendarutils.js
+++ b/calendarutils.js
@@ -9,6 +9,7 @@
  * @external Moment
  */
 const moment = require("moment");
+require("moment-timezone");
 const path = require("path");
 const zoneTable = require(path.join(__dirname, "windowsZones.json"));
 const Log = require("../../js/logger.js");


### PR DESCRIPTION
## Summary

Explicitly load `moment-timezone` before `calendarutils.js` uses the `moment.tz` API.

## Problem

`calendarutils.js` imports `moment` and later calls both `moment.tz()` and `moment.tz.guess()`. In the MagicMirror 2.37 node-helper environment, importing `moment` alone does not initialize the timezone plugin.

This causes calendar processing to fail with errors such as:

```text
TypeError: moment.tz is not a function
TypeError: Cannot read properties of undefined (reading 'guess')
```

The node helper then sends `CALENDAR_ERROR`, and events do not render.

## Change

```diff
  const moment = require("moment");
+ require("moment-timezone");
  const path = require("path");
```

No dependency update is required because `moment-timezone` is already available in the tested MagicMirror environment; it only needs to be loaded before the timezone APIs are used.

## Validation

- `git diff --check`
- `node --check calendarutils.js`
- Tested with MagicMirror 2.37.0 and Node.js 24.18.1
- Reproduced both timezone errors before the change
- Confirmed the errors and `CALENDAR_ERROR` are absent afterward
- Confirmed calendar events render successfully

## Scope

This branch is based directly on upstream `master` and contains one commit adding one line to one file.

The renderer-side `structuredClone()` compatibility change is isolated in a separate pull request. Deployment validation used both independent fixes together on a runtime branch based on `dbeltjr/master`.