### PR TITLE
Fix event broadcasting on MagicMirror 2.37

### DIFF
--- a/MMM-MyCalendar.js
+++ b/MMM-MyCalendar.js
@@ -501,7 +501,7 @@ Module.register("MMM-MyCalendar", {
 		for (url in this.calendarData) {
 			var calendar = this.calendarData[url];
 			for (e in calendar) {
-				var event = cloneObject(calendar[e]);
+				const event = structuredClone(calendar[e]);
 				delete event.url;
 				eventList.push(event);
 			}


### PR DESCRIPTION
## Summary

Replace the unavailable global `cloneObject()` helper with the standardized `structuredClone()` API when preparing the `CALENDAR_EVENTS` payload.

## Problem

MagicMirror 2.37 moved its core classes and helpers to ES modules. `cloneObject()` still exists internally, but is no longer exposed as a browser global. Consequently, `MMM-MyCalendar` throws:

`ReferenceError: cloneObject is not defined`

Because this occurs in `broadcastEvents()` before `updateDom()`, fetched events are not rendered when event broadcasting is enabled.

## Change

```diff
- var event = cloneObject(calendar[e]);
+ const event = structuredClone(calendar[e]);
```

## Validation

- `git diff --check`
- `node --check MMM-MyCalendar.js`
- Tested in a MagicMirror 2.37.0 Compose deployment
- Confirmed `typeof globalThis.structuredClone === "function"` in Firefox 153
- Confirmed calendar events render
- Confirmed no `cloneObject` `ReferenceError` or `DataCloneError`

## Scope

This branch is based directly on upstream `master` and contains one commit changing one file. It intentionally does not include or supersede #44 or #45.

Deployment testing used a separate branch based on `dbeltjr/master`. That branch also contains an independent `moment-timezone` compatibility fix, which is being submitted separately.